### PR TITLE
Use std::stof for string2float

### DIFF
--- a/src/float.cpp
+++ b/src/float.cpp
@@ -26,7 +26,12 @@ namespace sexp {
 
 float string2float(const std::string& text)
 {
-  return std::stof(text);
+  std::istringstream iss(text);
+  iss.imbue(std::locale::classic());
+  float result;
+  iss >> result;
+  assert(!iss.eof());
+  return result;
 }
 
 void float2string(std::ostream& os, float value)

--- a/src/float.cpp
+++ b/src/float.cpp
@@ -26,17 +26,7 @@ namespace sexp {
 
 float string2float(const std::string& text)
 {
-  char const* start = text.data();
-
-  // A leading + (e.g. "+5") is not accepted by from_chars(), so skip it
-  if (!text.empty() && text[0] == '+') {
-    start += 1;
-  }
-
-  float result;
-  [[maybe_unused]] auto err = std::from_chars(start, text.data() + text.size(), result);
-  assert(err.ec == std::errc());
-  return result;
+  return std::stof(text);
 }
 
 void float2string(std::ostream& os, float value)


### PR DESCRIPTION
This wouldn't build on FreeBSD anyway. Solution seems cleaner and takes care of the +. Also supports `e` as well, but that shouldn't matter as that should be up to the sexp parser I think.